### PR TITLE
Added support for HX-Reselect header (htmx 1.9.3)

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,6 @@
 Revision history for Perl extension Mojolicious::Plugin::HTMX.
 
+    - Added support for HX-Reselect header (htmx 1.9.3)
+
 1.00 2022-10-28
     - First release of Mojolicious::Plugin::HTMX

--- a/lib/Mojolicious/Plugin/HTMX.pm
+++ b/lib/Mojolicious/Plugin/HTMX.pm
@@ -51,6 +51,7 @@ sub register {
     $app->helper('htmx.res.refresh'     => \&_res_refresh);
     $app->helper('htmx.res.replace_url' => \&_res_replace_url);
     $app->helper('htmx.res.reswap'      => \&_res_reswap);
+    $app->helper('htmx.res.reselect'    => \&_res_reselect);
     $app->helper('htmx.res.retarget'    => \&_res_retarget);
 
     $app->helper('htmx.res.trigger'              => sub { _res_trigger('default',      @_) });
@@ -143,6 +144,15 @@ sub _res_reswap {
     Carp::croak "Unknown reswap value" if (!$is_reswap);
 
     return $c->res->headers->header('HX-Reswap' => $reswap);
+
+}
+
+sub _res_reselect {
+
+    my ($c, $reselect) = @_;
+    return undef unless $reselect;
+
+    return $c->res->headers->header('HX-Reselect' => $reselect);
 
 }
 
@@ -363,6 +373,12 @@ The possible values of this attribute are:
 =back
 
 Based on C<HX-Reswap> header.
+
+=head3 htmx->res->reselect
+
+A CSS selector that allows you to choose which part of the response is used to be swapped in. Overrides an existing C<hx-select> on the triggering element
+
+Based on C<HX-Reselect> header.
 
 =head3 htmx->res->retarget
 

--- a/t/basic.t
+++ b/t/basic.t
@@ -106,6 +106,19 @@ subtest 'Response: HX-Reswap' => sub {
 
 };
 
+subtest 'Response: HX-Reselect' => sub {
+
+    get '/hx_reselect_1' => sub {
+        my $c = shift;
+        $c->htmx->res->reselect('#test');
+        $c->rendered(200);
+    };
+
+    $t->get_ok('/hx_reselect_1')->status_is(200)->header_exists('HX-Reselect');
+    $t->get_ok('/hx_reselect_1')->status_is(200)->header_is('HX-Reselect', '#test');
+
+};
+
 subtest 'Response: HX-Retarget' => sub {
 
     get '/hx_retarget_1' => sub {


### PR DESCRIPTION
This adds support for the newly added HX-Reselect HTTP response header in htmx 1.9.3.